### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Cocoapods platforms](http://img.shields.io/cocoapods/p/Carnival.svg?style=flat)](http://img.shields.io/cocoapods/p/Carnival.svg?style=flat)
-[![Cocoapods license](http://img.shields.io/cocoapods/l/Carnival.svg?style=flat)](http://img.shields.io/cocoapods/l/Carnival.svg?style=flat)
-[![Cocoapods pod version](http://img.shields.io/cocoapods/v/Carnival.svg?style=flat)](http://img.shields.io/cocoapods/v/Carnival.svg?style=flat)
+[![CocoaPods platforms](http://img.shields.io/cocoapods/p/Carnival.svg?style=flat)](http://img.shields.io/cocoapods/p/Carnival.svg?style=flat)
+[![CocoaPods license](http://img.shields.io/cocoapods/l/Carnival.svg?style=flat)](http://img.shields.io/cocoapods/l/Carnival.svg?style=flat)
+[![CocoaPods pod version](http://img.shields.io/cocoapods/v/Carnival.svg?style=flat)](http://img.shields.io/cocoapods/v/Carnival.svg?style=flat)
 
 Carnival Mobile SDK for iOS
 ==========================


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
